### PR TITLE
Polling the deployment of service until all the old container are removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ Execute from the working directory:
 
 ```sh
 AWS_ACCESS_KEY_ID=xxxx \
-AWS_SECRET_KEY=xxxx \
+AWS_SECRET_ACCESS_KEY=xxxx \
 PLUGIN_CLUSTER=ecs-cluster \
 PLUGIN_SERVICE=ecs-service \
 PLUGIN_AWS_REGION=ap-southeast-1 \
+PLUGIN_POLLING_CHECK_ENABLE=true \
 PLUGIN_IMAGE_NAME=xxxx.dkr.ecr.xxx.amazon.com/simple_app:latest \
   ./drone-ecs-deploy
 ```

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ var Version string
 
 func main() {
 	if Version == "" {
-		Version = fmt.Sprintf("0.0.1+%s", build)
+		Version = fmt.Sprintf("0.0.2+%s", build)
 	}
 
 	app := cli.NewApp()
@@ -58,6 +58,23 @@ func main() {
 			Usage:  "Path to save the dotenv file",
 			EnvVar: "PLUGIN_DEPLOY_ENV_PATH",
 			Value:  ".deploy.env",
+		},
+		cli.BoolFlag{
+			Name:   "polling-check-enable",
+			Usage:  "Enable checking on removing old task definition (default: false)",
+			EnvVar: "PLUGIN_POLLING_CHECK_ENABLE",
+		},
+		cli.IntFlag{
+			Name:   "polling-interval",
+			Usage:  "Interval for ensuring old task definition is replaced (default: 10 sec)",
+			EnvVar: "PLUGIN_POLLING_INTERVAL",
+			Value:  10,
+		},
+		cli.IntFlag{
+			Name:   "polling-timeout",
+			Usage:  "Timeout for ensuring old task definition is replaced (default: 10 mins)",
+			EnvVar: "PLUGIN_POLLING_TIMEOUT",
+			Value:  600,
 		},
 		cli.StringFlag{
 			Name:  "env-file",
@@ -104,11 +121,14 @@ func run(c *cli.Context) error {
 
 	plugin := Plugin{
 		Config: Config{
-			Cluster:       c.String("cluster"),
-			Service:       c.String("service"),
-			AwsRegion:     c.String("aws_region"),
-			ImageName:     c.String("image_name"),
-			DeployEnvPath: c.String("deploy-env-path"),
+			Cluster:            c.String("cluster"),
+			Service:            c.String("service"),
+			AwsRegion:          c.String("aws_region"),
+			ImageName:          c.String("image_name"),
+			DeployEnvPath:      c.String("deploy-env-path"),
+			PollingCheckEnable: c.Bool("polling-check-enable"),
+			PollingInterval:    c.Int("polling-interval"),
+			PollingTimeout:     c.Int("polling-timeout"),
 		},
 	}
 


### PR DESCRIPTION
Usage:
```
  deploy_to_ecs:
    image: moneysmartco/drone-ecs-deploy:0.0.2
    cluster: xxx
    service: xxx
    aws_region: ap-southeast-1
    image_name: xxx.dkr.ecr.ap-southeast-1.amazonaws.com/xxx:${DRONE_COMMIT:0:10}
    polling_check_enable: true
    polling_interval: 10
    polling_timeout: 600
    secrets:
      - aws_access_key_id
      - aws_secret_access_key
```